### PR TITLE
feature: use jmespath library to support parsing multi-level username key and so on when using oauth

### DIFF
--- a/connector/oauth/oauth.go
+++ b/connector/oauth/oauth.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/dexidp/dex/connector"
 	"github.com/dexidp/dex/pkg/log"
+	"github.com/jmespath/go-jmespath"
 )
 
 type oauthConnector struct {
@@ -201,29 +202,34 @@ func (c *oauthConnector) HandleCallback(s connector.Scopes, r *http.Request) (id
 		return identity, fmt.Errorf("OAuth Connector: failed to execute request to userinfo: status %d", userInfoResp.StatusCode)
 	}
 
-	var userInfoResult map[string]interface{}
+	var userInfoResult interface{}
 	err = json.NewDecoder(userInfoResp.Body).Decode(&userInfoResult)
 	if err != nil {
 		c.logger.Errorf("OAuth Connector: failed to parse userinfo: %v", err)
 		return identity, fmt.Errorf("OAuth Connector: failed to parse userinfo: %v", err)
 	}
 
-	userID, found := userInfoResult[c.userIDKey].(string)
+	tmpUserID, _ := jmespath.Search(c.userIDKey, userInfoResult)
+	userID, found := tmpUserID.(string)
 	if !found {
 		c.logger.Errorf("OAuth Connector: not found %v claim", c.userIDKey)
 		return identity, fmt.Errorf("OAuth Connector: not found %v claim", c.userIDKey)
 	}
 
 	identity.UserID = userID
-	identity.Username, _ = userInfoResult[c.userNameKey].(string)
-	identity.PreferredUsername, _ = userInfoResult[c.preferredUsernameKey].(string)
-	identity.Email, _ = userInfoResult[c.emailKey].(string)
-	identity.EmailVerified, _ = userInfoResult[c.emailVerifiedKey].(bool)
+	username, _ := jmespath.Search(c.userNameKey, userInfoResult)
+	identity.Username, _ = username.(string)
+	preferredUsername, _ := jmespath.Search(c.preferredUsernameKey, userInfoResult)
+	identity.PreferredUsername, _ = preferredUsername.(string)
+	email, _ := jmespath.Search(c.emailKey, userInfoResult)
+	identity.Email, _ = email.(string)
+	emailVerified, _ := jmespath.Search(c.emailVerifiedKey, userInfoResult)
+	identity.EmailVerified, _ = emailVerified.(bool)
 
 	if s.Groups {
 		groups := map[string]struct{}{}
 
-		c.addGroupsFromMap(groups, userInfoResult)
+		c.addGroups(groups, userInfoResult)
 		c.addGroupsFromToken(groups, token.AccessToken)
 
 		for groupName := range groups {
@@ -243,8 +249,9 @@ func (c *oauthConnector) HandleCallback(s connector.Scopes, r *http.Request) (id
 	return identity, nil
 }
 
-func (c *oauthConnector) addGroupsFromMap(groups map[string]struct{}, result map[string]interface{}) error {
-	groupsClaim, ok := result[c.groupsKey].([]interface{})
+func (c *oauthConnector) addGroups(groups map[string]struct{}, result interface{}) error {
+	tmpGroupsClaim, _ := jmespath.Search(c.groupsKey, result)
+	groupsClaim, ok := tmpGroupsClaim.([]interface{})
 	if !ok {
 		return errors.New("cannot convert to slice")
 	}
@@ -252,6 +259,12 @@ func (c *oauthConnector) addGroupsFromMap(groups map[string]struct{}, result map
 	for _, group := range groupsClaim {
 		if groupString, ok := group.(string); ok {
 			groups[groupString] = struct{}{}
+			continue
+		}
+		if groupMap, ok := group.(map[string]interface{}); ok {
+			if groupName, ok := groupMap["name"].(string); ok {
+				groups[groupName] = struct{}{}
+			}
 		}
 	}
 
@@ -269,13 +282,13 @@ func (c *oauthConnector) addGroupsFromToken(groups map[string]struct{}, token st
 		return err
 	}
 
-	var claimsMap map[string]interface{}
+	var claimsMap interface{}
 	err = json.Unmarshal(decoded, &claimsMap)
 	if err != nil {
 		return err
 	}
 
-	return c.addGroupsFromMap(groups, claimsMap)
+	return c.addGroups(groups, claimsMap)
 }
 
 func decode(seg string) ([]byte, error) {

--- a/connector/oauth/oauth_test.go
+++ b/connector/oauth/oauth_test.go
@@ -1,0 +1,419 @@
+package oauth
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	jose "gopkg.in/square/go-jose.v2"
+
+	"github.com/dexidp/dex/connector"
+)
+
+func TestOpen(t *testing.T) {
+	tokenClaims := map[string]interface{}{}
+	userInfoClaims := map[string]interface{}{}
+
+	testServer := testSetup(t, tokenClaims, userInfoClaims)
+	defer testServer.Close()
+
+	conn := newConnector(t, testServer.URL)
+
+	sort.Strings(conn.scopes)
+
+	assert.Equal(t, conn.clientID, "testClient")
+	assert.Equal(t, conn.clientSecret, "testSecret")
+	assert.Equal(t, conn.redirectURI, testServer.URL+"/callback")
+	assert.Equal(t, conn.tokenURL, testServer.URL+"/token")
+	assert.Equal(t, conn.authorizationURL, testServer.URL+"/authorize")
+	assert.Equal(t, conn.userInfoURL, testServer.URL+"/userinfo")
+	assert.Equal(t, len(conn.scopes), 2)
+	assert.Equal(t, conn.scopes[0], "groups")
+	assert.Equal(t, conn.scopes[1], "openid")
+}
+
+func TestLoginURL(t *testing.T) {
+	tokenClaims := map[string]interface{}{}
+	userInfoClaims := map[string]interface{}{}
+
+	testServer := testSetup(t, tokenClaims, userInfoClaims)
+	defer testServer.Close()
+
+	conn := newConnector(t, testServer.URL)
+
+	loginURL, err := conn.LoginURL(connector.Scopes{}, conn.redirectURI, "some-state")
+	assert.Equal(t, err, nil)
+
+	expectedURL, err := url.Parse(testServer.URL + "/authorize")
+	assert.Equal(t, err, nil)
+
+	values := url.Values{}
+	values.Add("client_id", "testClient")
+	values.Add("redirect_uri", conn.redirectURI)
+	values.Add("response_type", "code")
+	values.Add("scope", "openid groups")
+	values.Add("state", "some-state")
+	expectedURL.RawQuery = values.Encode()
+
+	assert.Equal(t, loginURL, expectedURL.String())
+}
+
+func TestHandleCallBackForGroupsInUserInfo(t *testing.T) {
+	tokenClaims := map[string]interface{}{}
+
+	userInfoClaims := map[string]interface{}{
+		"name":               "test-name",
+		"user_id_key":        "test-user-id",
+		"user_name_key":      "test-username",
+		"preferred_username": "test-preferred-username",
+		"mail":               "mod_mail",
+		"has_verified_email": false,
+		"groups_key":         []string{"admin-group", "user-group"},
+	}
+
+	testServer := testSetup(t, tokenClaims, userInfoClaims)
+	defer testServer.Close()
+
+	conn := newConnector(t, testServer.URL)
+	req := newRequestWithAuthCode(t, testServer.URL, "some-code")
+
+	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, req)
+	assert.Equal(t, err, nil)
+
+	sort.Strings(identity.Groups)
+	assert.Equal(t, len(identity.Groups), 2)
+	assert.Equal(t, identity.Groups[0], "admin-group")
+	assert.Equal(t, identity.Groups[1], "user-group")
+	assert.Equal(t, identity.UserID, "test-user-id")
+	assert.Equal(t, identity.Username, "test-username")
+	assert.Equal(t, identity.PreferredUsername, "test-preferred-username")
+	assert.Equal(t, identity.Email, "mod_mail")
+	assert.Equal(t, identity.EmailVerified, false)
+}
+
+func TestHandleCallBackForGroupMapsInUserInfo(t *testing.T) {
+	tokenClaims := map[string]interface{}{}
+
+	userInfoClaims := map[string]interface{}{
+		"name":               "test-name",
+		"user_id_key":        "test-user-id",
+		"user_name_key":      "test-username",
+		"preferred_username": "test-preferred-username",
+		"mail":               "mod_mail",
+		"has_verified_email": false,
+		"groups_key": []interface{}{
+			map[string]string{"name": "admin-group", "id": "111"},
+			map[string]string{"name": "user-group", "id": "222"},
+		},
+	}
+
+	testServer := testSetup(t, tokenClaims, userInfoClaims)
+	defer testServer.Close()
+
+	conn := newConnector(t, testServer.URL)
+	req := newRequestWithAuthCode(t, testServer.URL, "some-code")
+
+	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, req)
+	assert.Equal(t, err, nil)
+
+	sort.Strings(identity.Groups)
+	assert.Equal(t, len(identity.Groups), 2)
+	assert.Equal(t, identity.Groups[0], "admin-group")
+	assert.Equal(t, identity.Groups[1], "user-group")
+	assert.Equal(t, identity.UserID, "test-user-id")
+	assert.Equal(t, identity.Username, "test-username")
+	assert.Equal(t, identity.PreferredUsername, "test-preferred-username")
+	assert.Equal(t, identity.Email, "mod_mail")
+	assert.Equal(t, identity.EmailVerified, false)
+}
+
+func TestHandleCallBackForGroupsInToken(t *testing.T) {
+	tokenClaims := map[string]interface{}{
+		"groups_key": []string{"test-group"},
+	}
+
+	userInfoClaims := map[string]interface{}{
+		"name":               "test-name",
+		"user_id_key":        "test-user-id",
+		"user_name_key":      "test-username",
+		"preferred_username": "test-preferred-username",
+		"email":              "test-email",
+		"email_verified":     true,
+	}
+
+	testServer := testSetup(t, tokenClaims, userInfoClaims)
+	defer testServer.Close()
+
+	conn := newConnector(t, testServer.URL)
+	req := newRequestWithAuthCode(t, testServer.URL, "some-code")
+
+	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, req)
+	assert.Equal(t, err, nil)
+
+	assert.Equal(t, len(identity.Groups), 1)
+	assert.Equal(t, identity.Groups[0], "test-group")
+	assert.Equal(t, identity.PreferredUsername, "test-preferred-username")
+	assert.Equal(t, identity.UserID, "test-user-id")
+	assert.Equal(t, identity.Username, "test-username")
+	assert.Equal(t, identity.Email, "")
+	assert.Equal(t, identity.EmailVerified, false)
+}
+
+func TestHandleCallBackForAttrPathPrefix(t *testing.T) {
+	tokenClaims := map[string]interface{}{}
+
+	userInfoClaims := map[string]interface{}{
+		"data": map[string]interface{}{
+			"name":               "test-name",
+			"user_id_key":        "test-user-id",
+			"user_name_key":      "test-username",
+			"preferred_username": "test-preferred-username",
+			"mail":               "mod_mail",
+			"has_verified_email": false,
+		},
+	}
+
+	testServer := testSetup(t, tokenClaims, userInfoClaims)
+	defer testServer.Close()
+
+	conn := newConnector(t, testServer.URL, "data")
+	req := newRequestWithAuthCode(t, testServer.URL, "some-code")
+
+	identity, err := conn.HandleCallback(connector.Scopes{}, req)
+	assert.Equal(t, err, nil)
+
+	assert.Equal(t, identity.UserID, "test-user-id")
+	assert.Equal(t, identity.Username, "test-username")
+	assert.Equal(t, identity.PreferredUsername, "test-preferred-username")
+	assert.Equal(t, identity.Email, "mod_mail")
+	assert.Equal(t, identity.EmailVerified, false)
+}
+
+func TestHandleCallBackForGroupsInUserInfoWithAttrPath(t *testing.T) {
+	tokenClaims := map[string]interface{}{}
+
+	userInfoClaims := map[string]interface{}{
+		"data": map[string]interface{}{
+			"name":               "test-name",
+			"user_id_key":        "test-user-id",
+			"user_name_key":      "test-username",
+			"preferred_username": "test-preferred-username",
+			"mail":               "mod_mail",
+			"has_verified_email": false,
+			"groups_key":         []string{"admin-group", "user-group"},
+		},
+	}
+
+	testServer := testSetup(t, tokenClaims, userInfoClaims)
+	defer testServer.Close()
+
+	conn := newConnector(t, testServer.URL, "data")
+	req := newRequestWithAuthCode(t, testServer.URL, "some-code")
+
+	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, req)
+	assert.Equal(t, err, nil)
+
+	sort.Strings(identity.Groups)
+	assert.Equal(t, len(identity.Groups), 2)
+	assert.Equal(t, identity.Groups[0], "admin-group")
+	assert.Equal(t, identity.Groups[1], "user-group")
+	assert.Equal(t, identity.UserID, "test-user-id")
+	assert.Equal(t, identity.Username, "test-username")
+	assert.Equal(t, identity.PreferredUsername, "test-preferred-username")
+	assert.Equal(t, identity.Email, "mod_mail")
+	assert.Equal(t, identity.EmailVerified, false)
+}
+
+func TestHandleCallBackForGroupMapsInUserInfoWithAttrPath(t *testing.T) {
+	tokenClaims := map[string]interface{}{}
+
+	userInfoClaims := map[string]interface{}{
+		"data": map[string]interface{}{
+			"name":               "test-name",
+			"user_id_key":        "test-user-id",
+			"user_name_key":      "test-username",
+			"preferred_username": "test-preferred-username",
+			"mail":               "mod_mail",
+			"has_verified_email": false,
+			"groups_key": []interface{}{
+				map[string]string{"name": "admin-group", "id": "111"},
+				map[string]string{"name": "user-group", "id": "222"},
+			},
+		},
+	}
+
+	testServer := testSetup(t, tokenClaims, userInfoClaims)
+	defer testServer.Close()
+
+	conn := newConnector(t, testServer.URL, "data")
+	req := newRequestWithAuthCode(t, testServer.URL, "some-code")
+
+	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, req)
+	assert.Equal(t, err, nil)
+
+	sort.Strings(identity.Groups)
+	assert.Equal(t, len(identity.Groups), 2)
+	assert.Equal(t, identity.Groups[0], "admin-group")
+	assert.Equal(t, identity.Groups[1], "user-group")
+	assert.Equal(t, identity.UserID, "test-user-id")
+	assert.Equal(t, identity.Username, "test-username")
+	assert.Equal(t, identity.PreferredUsername, "test-preferred-username")
+	assert.Equal(t, identity.Email, "mod_mail")
+	assert.Equal(t, identity.EmailVerified, false)
+}
+
+func TestHandleCallBackForGroupsInTokenWithAttrPath(t *testing.T) {
+	tokenClaims := map[string]interface{}{
+		"data": map[string]interface{}{
+			"groups_key": []string{"test-group"},
+		},
+	}
+
+	userInfoClaims := map[string]interface{}{
+		"data": map[string]interface{}{
+			"name":               "test-name",
+			"user_id_key":        "test-user-id",
+			"user_name_key":      "test-username",
+			"preferred_username": "test-preferred-username",
+			"email":              "test-email",
+			"email_verified":     true,
+		},
+	}
+
+	testServer := testSetup(t, tokenClaims, userInfoClaims)
+	defer testServer.Close()
+
+	conn := newConnector(t, testServer.URL, "data")
+	req := newRequestWithAuthCode(t, testServer.URL, "some-code")
+
+	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, req)
+	assert.Equal(t, err, nil)
+
+	assert.Equal(t, len(identity.Groups), 1)
+	assert.Equal(t, identity.Groups[0], "test-group")
+	assert.Equal(t, identity.PreferredUsername, "test-preferred-username")
+	assert.Equal(t, identity.UserID, "test-user-id")
+	assert.Equal(t, identity.Username, "test-username")
+	assert.Equal(t, identity.Email, "")
+	assert.Equal(t, identity.EmailVerified, false)
+}
+
+func testSetup(t *testing.T, tokenClaims map[string]interface{}, userInfoClaims map[string]interface{}) *httptest.Server {
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatal("Failed to generate rsa key", err)
+	}
+
+	jwk := jose.JSONWebKey{
+		Key:       key,
+		KeyID:     "some-key",
+		Algorithm: "RSA",
+	}
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		token, err := newToken(&jwk, tokenClaims)
+		if err != nil {
+			t.Fatal("unable to generate token", err)
+		}
+
+		w.Header().Add("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(&map[string]string{
+			"access_token": token,
+			"id_token":     token,
+			"token_type":   "Bearer",
+		})
+	})
+
+	mux.HandleFunc("/userinfo", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(userInfoClaims)
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func newToken(key *jose.JSONWebKey, claims map[string]interface{}) (string, error) {
+	signingKey := jose.SigningKey{Key: key, Algorithm: jose.RS256}
+
+	signer, err := jose.NewSigner(signingKey, &jose.SignerOptions{})
+	if err != nil {
+		return "", fmt.Errorf("new signer: %v", err)
+	}
+
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("marshaling claims: %v", err)
+	}
+
+	signature, err := signer.Sign(payload)
+	if err != nil {
+		return "", fmt.Errorf("signing payload: %v", err)
+	}
+
+	return signature.CompactSerialize()
+}
+
+func newConnector(t *testing.T, serverURL string, attrPathPrefix ...string) *oauthConnector {
+	prefix := strings.Join(attrPathPrefix, ".")
+	if prefix != "" {
+		prefix += "."
+	}
+
+	testConfig := Config{
+		ClientID:         "testClient",
+		ClientSecret:     "testSecret",
+		RedirectURI:      serverURL + "/callback",
+		TokenURL:         serverURL + "/token",
+		AuthorizationURL: serverURL + "/authorize",
+		UserInfoURL:      serverURL + "/userinfo",
+		Scopes:           []string{"openid", "groups"},
+		UserIDKey:        prefix + "user_id_key",
+	}
+
+	testConfig.ClaimMapping.UserNameKey = prefix + "user_name_key"
+	testConfig.ClaimMapping.GroupsKey = prefix + "groups_key"
+	testConfig.ClaimMapping.EmailKey = prefix + "mail"
+	testConfig.ClaimMapping.EmailVerifiedKey = prefix + "has_verified_email"
+	if prefix != "" {
+		testConfig.ClaimMapping.PreferredUsernameKey = prefix + "preferred_username"
+	}
+
+	log := logrus.New()
+
+	conn, err := testConfig.Open("id", log)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oauthConn, ok := conn.(*oauthConnector)
+	if !ok {
+		t.Fatal(errors.New("failed to convert to oauthConnector"))
+	}
+
+	return oauthConn
+}
+
+func newRequestWithAuthCode(t *testing.T, serverURL string, code string) *http.Request {
+	req, err := http.NewRequest("GET", serverURL, nil)
+	if err != nil {
+		t.Fatal("failed to create request", err)
+	}
+
+	values := req.URL.Query()
+	values.Add("code", code)
+	req.URL.RawQuery = values.Encode()
+
+	return req
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+	github.com/jmespath/go-jmespath v0.4.0
 	github.com/kylelemons/godebug v1.1.0
 	github.com/lib/pq v1.10.2
 	github.com/mattermost/xml-roundtrip-validator v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -266,6 +266,10 @@ github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.0 h1:J2SLSdy7HgElq8ekSl2Mxh6vrRNFxqbXGenYH2I02Vs=
 github.com/jonboulle/clockwork v0.2.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=


### PR DESCRIPTION
Signed-off-by: zheyuan.xing <jevon.xing@miotech.com>

#### What this PR does / why we need it
1. use jmespath library to support parsing multi-level username key and so on when using oauth
2. add unit test for oauth

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
